### PR TITLE
Fix for errors whenever resizing the minibufexpl window.

### DIFF
--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -1056,12 +1056,18 @@ function! <SID>ResizeWindow()
         endif
       endif
     else
+      " We need to be able to modify the buffer
+      setlocal modifiable
+
       exec "setlocal textwidth=".l:width
       normal gg
       normal gq}
       normal G
       let l:height = line('.')
       normal gg
+
+      " Prevent the buffer from being modified.
+      setlocal nomodifiable
     endif
 
     " enforce max window height


### PR DESCRIPTION
With the current `develop` branch HEAD, whenever `<SID>ResizeWindow` gets called (whenever I switch buffers), I get the following error from Vim:

```
Error detected while processing function <SNR>39_BufEnterHandler..<SNR>39_AutoUpdate..<SNR>39_StartExplorer..<SNR>39_DisplayBuffers..<SNR>39_ResizeWindow:
line   36:
E21: Cannot make changes, 'modifiable' is off
```

This seems to be because of the `normal gq}` reformatting command in `<SID>ResizeWindow`, in the branch for when it's set to use a horizontal split (`g:miniBufExplVSplit == 0`), and tab wrapping is enabled. (`g:miniBufExplTabWrap != 0`)

This patch corrects this by adding `setlocal modifiable`/`setlocal nomodifiable` around that section of the code.
