### PR TITLE
wrap norelativenumber in a feature check for Vim versions < 7.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-/mbe_flow
-/plugin/minibufexpl_checkiflastbuffer.vim

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /mbe_flow
 /plugin/minibufexpl_checkiflastbuffer.vim
+/doc/tags

--- a/doc/minibufexpl.txt
+++ b/doc/minibufexpl.txt
@@ -132,11 +132,11 @@ Vertical
 
 By default the vertical explorer has a fixed width . If you put:
 
-  let g:miniBufExplMaxSize = <max width: default 0> 
+  let g:miniBufExplMaxSize = <max width: default 0>
 
 into your .vimrc then MBE will attempt to set the width of the MBE window to
 be as wide as your widest tab. The width will not exceed MaxSize even if you
-have wider tabs. 
+have wider tabs.
 
 Accepting the default value of 0 for this will give you a fixed width MBE
 window.
@@ -175,7 +175,7 @@ By default we are now (as of 6.0.1) turning on the MoreThanOne option. This
 stops the -MiniBufExplorer- from opening automatically until more than one
 eligible buffer is available. You can turn this feature off by setting the
 following variable in your .vimrc:
-  
+
   let g:miniBufExplorerMoreThanOne=1
 
 (The following enhancement is as of 6.2.2) Setting this to 0 will cause the
@@ -216,8 +216,8 @@ into your .vimrc:
   let g:miniBufExplMapCTabSwitchWindows = 1
 
 
-NOTE: If you set the ...TabSwitchBufs AND ...TabSwitchWindows, 
-      ...TabSwitchBufs will be enabled and ...TabSwitchWindows 
+NOTE: If you set the ...TabSwitchBufs AND ...TabSwitchWindows,
+      ...TabSwitchBufs will be enabled and ...TabSwitchWindows
       will not.
 
 ------------------------------------------------------------------------------
@@ -229,11 +229,11 @@ As of MBE 6.3.0, you can put the following into your .vimrc:
   let g:miniBufExplUseSingleClick = 1
 
 If you would like to single click on tabs rather than double clicking on them
-to goto the selected buffer. 
+to goto the selected buffer.
 
-NOTE: If you use the single click option in taglist.vim you may 
-      need to get an updated version that includes a patch I 
-      provided to allow both explorers to provide single click 
+NOTE: If you use the single click option in taglist.vim you may
+      need to get an updated version that includes a patch I
+      provided to allow both explorers to provide single click
       buffer selection.
 
                                                  *'g:miniBufExplModSelTarget'*
@@ -290,7 +290,7 @@ the following into your .vimrc:
 You can also set a DebugMode to cause output to be target as follows (default
 is mode 3):
 
-  let g:miniBufExplorerDebugMode  = 0  " Errors will show up in 
+  let g:miniBufExplorerDebugMode  = 0  " Errors will show up in
                                        " a vim window
   let g:miniBufExplorerDebugMode  = 1  " Uses VIM's echo function
                                        " to display on the screen
@@ -316,7 +316,7 @@ configuring the following highlighting groups:
                             VISIBLE
   MBEVisibleNormalActive  - buffers that have NOT CHANGED and are
                             VISIBLE and is the active buffer
-  MBEVisibleChanged       - for buffers that have CHANGED and are 
+  MBEVisibleChanged       - for buffers that have CHANGED and are
                             VISIBLE
   MBEVisibleChangedActive - buffers that have CHANGED and are VISIBLE
                             and is the active buffer
@@ -353,14 +353,14 @@ might not take you to the expected window.
   where multiple files have the same name but are in different
   locations.
 - Add the ability to specify a regexp for eligible buffers
-  allowing the ability to filter out certain buffers that 
+  allowing the ability to filter out certain buffers that
   you don't want to control from MBE.
 
 
 ==============================================================================
 7. About                                                    *MiniBufExplAbout*
 
-    Copyright: Copyright (C) 2002 & 2003 Bindu Wavell 
+    Copyright: Copyright (C) 2002 & 2003 Bindu Wavell
                Copyright (C) 2010 Oliver Uvman
                Copyright (C) 2010 Danielle Church
                Copyright (C) 2010 Stephan Sokolow
@@ -403,7 +403,7 @@ might not take you to the expected window.
     - Fix MBE losing highlighting when a buffer is closed.
       Thanks to Markus Koller for the pull request!
     - Disable spellcheck on MBE buffer.
-    - Don't use colorcolumn setting on MBE buffer. Thanks to 
+    - Don't use colorcolumn setting on MBE buffer. Thanks to
       grassofhust for the pull requests for this and the
       previous issue!
 
@@ -478,7 +478,7 @@ might not take you to the expected window.
     - Added additional keybindings. In addition to <TAB> and
       <S-TAB>, l and h can now be used. In addition to <CR>,
       and e can now be used.
-    - You can open the selected buffer in a new split window 
+    - You can open the selected buffer in a new split window
       by pressing s while in the minibufexplorer window.
     - You can open the selected buffer in a new vertically
       split window while pressing v while in the
@@ -486,24 +486,24 @@ might not take you to the expected window.
 
 6.3.2
     - For some reason there was still a call to StopExplorer
-      with 2 params. Very old bug. I know I fixed before, 
+      with 2 params. Very old bug. I know I fixed before,
       any way many thanks to Jason Mills for reporting this!
 
 6.3.1
-    - Include folds in source so that it's easier to 
+    - Include folds in source so that it's easier to
       navigate.
     - Added g:miniBufExplForceSyntaxEnable setting for folks
-      that want a :syntax enable to be called when we enter 
+      that want a :syntax enable to be called when we enter
       buffers. This can resolve issues caused by a vim bug
-      where buffers show up without highlighting when another 
+      where buffers show up without highlighting when another
       buffer has been closed, quit, wiped or deleted.
 
 6.3.0
     - Added an option to allow single click (rather than
       the default double click) to select buffers in the
       MBE window. This feature was requested by AW Law
-      and was inspired by taglist.vim. Note that you will 
-      need the latest version of taglist.vim if you want to 
+      and was inspired by taglist.vim. Note that you will
+      need the latest version of taglist.vim if you want to
       use MBE and taglist both with singleclick turned on.
       Also thanks to AW Law for pointing out that you can
       make an Explorer not be listed in a standard :ls.
@@ -536,30 +536,30 @@ might not take you to the expected window.
 6.2.6
     - Moved history to end of source file
     - Updated highlighting documentation
-    - Created global commands MBEbn and MBEbp that can be 
-      used in mappings if folks want to cycle buffers while 
+    - Created global commands MBEbn and MBEbp that can be
+      used in mappings if folks want to cycle buffers while
       skipping non-eligible buffers.
 
 6.2.5
     - Added <Leader>mbt key mapping which will toggle
       the MBE window. I map this to F3 in my .vimrc
-      with "map <F3> :TMiniBufExplorer<CR>" which 
-      means I can easily close the MBE window when I'm 
+      with "map <F3> :TMiniBufExplorer<CR>" which
+      means I can easily close the MBE window when I'm
       not using it and get it back when I want it.
     - Changed default debug mode to 3 (write to global
       g:miniBufExplorerDebugOutput)
-    - Made a pass through the documentation to clarify 
+    - Made a pass through the documentation to clarify
       serveral issues and provide more complete docs
       for mappings and commands.
 
 6.2.4
-    - Because of the autocommand switch (see 6.2.0) it 
+    - Because of the autocommand switch (see 6.2.0) it
       was possible to remove the restriction on the
       :set hidden option. It is now possible to use
       this option with MBE.
 
 6.2.3
-    - Added miniBufExplTabWrap option. It is turned 
+    - Added miniBufExplTabWrap option. It is turned
       off by default. When turned on spaces are added
       between tabs and gq} is issued to perform line
       formatting. This won't work very well if filenames
@@ -583,13 +583,13 @@ might not take you to the expected window.
       NOTE: in 6.3.0 we started using MinSize instead of
       Minheight. This will still work if MinSize is not
       specified, but it is depreciated. Use MinSize instead.
-    - I now setlocal foldcolumn=0 and nonumber in the MBE 
+    - I now setlocal foldcolumn=0 and nonumber in the MBE
       window. This is for those of you that like to have
       these options turned on locally. I'm assuming noone
       outthere wants foldcolumns and line numbers in the
       MBE window? :)
     - Fixed a bug where an empty MBE window was taking half
-      of the screen (partly why the MinHeight option was 
+      of the screen (partly why the MinHeight option was
       added.)
 
 6.2.1
@@ -599,15 +599,15 @@ might not take you to the expected window.
     - The <Leader>mbe mapping now highlights the buffer from
       the current window.
     - The delete ('d') binding in the MBE window now restors
-      the cursor position, which can help if you want to 
+      the cursor position, which can help if you want to
       delete several buffers in a row that are not at the
       beginning of the buffer list.
-    - Added a new key binding ('p') in the MBE window to 
+    - Added a new key binding ('p') in the MBE window to
       switch to the previous window (last edit window)
 
 6.2.0
     - Major overhaul of autocommand and list updating code,
-      we now have much better handling of :bd (which is the 
+      we now have much better handling of :bd (which is the
       most requested feature.) As well as resolving other
       issues where the buffer list would not be updated
       automatically. The old version tried to trap specific
@@ -621,7 +621,7 @@ might not take you to the expected window.
       MaxHeight. This will still work if MaxSize is not
       specified, but it is depreciated. Use MaxSize instead.
     - Improvement to internal syntax highlighting code
-      I renamed the syntax group names. Anyone who has 
+      I renamed the syntax group names. Anyone who has
       figured out how to use them already shouldn't have
       any trouble with the new Nameing :)
     - Added debug mode 3 which writes to a global variable
@@ -636,8 +636,8 @@ might not take you to the expected window.
       idiocyncracies.)
 
 6.0.9
-    - Double clicking tabs was overwriting the cliboard 
-      register on MS Windows.  Thanks to Shoeb Bhinderwala 
+    - Double clicking tabs was overwriting the cliboard
+      register on MS Windows.  Thanks to Shoeb Bhinderwala
       for reporting this issue.
 
 6.0.8
@@ -651,52 +651,52 @@ might not take you to the expected window.
       a buffer which can then be written to disk or emailed
       to me when someone is having a major issue. Can also
       write directly to a file (VERY SLOWLY) on UNIX or Win32
-      (not 95 or 98 at the moment) or use VIM's echo function 
+      (not 95 or 98 at the moment) or use VIM's echo function
       to display the output to the screen.
-    - Several people have had issues when the hidden option 
+    - Several people have had issues when the hidden option
       is turned on. So I have put in several checks to make
       sure folks know this if they try to use MBE with this
       option set.
 
 6.0.7
-    - Handling BufDelete autocmd so that the UI updates 
-      properly when using :bd (rather than going through 
+    - Handling BufDelete autocmd so that the UI updates
+      properly when using :bd (rather than going through
       the MBE UI.)
-    - The AutoUpdate code will now close the MBE window when 
+    - The AutoUpdate code will now close the MBE window when
       there is a single eligible buffer available.
       This has the usefull side effect of stopping the MBE
-      window from blocking the VIM session open when you close 
+      window from blocking the VIM session open when you close
       the last buffer.
     - Added functions, commands and maps to close & update
       the MBE window (<leader>mbc and <leader>mbu.)
     - Made MBE open/close state be sticky if set through
-      StartExplorer(1) or StopExplorer(1), which are 
+      StartExplorer(1) or StopExplorer(1), which are
       called from the standard mappings. So if you close
-      the mbe window with \mbc it won't be automatically 
+      the mbe window with \mbc it won't be automatically
       opened again unless you do a \mbe (or restart VIM).
     - Removed spaces between "tabs" (even more mini :)
-    - Simplified MBE tab processing 
+    - Simplified MBE tab processing
 
 6.0.6
     - Fixed register overwrite bug found by S?bastien Pierre
 
 6.0.5
-    - Fixed an issue with window sizing when we run out of 
-      buffers.  
-    - Fixed some weird commenting bugs.  
+    - Fixed an issue with window sizing when we run out of
+      buffers.
+    - Fixed some weird commenting bugs.
     - Added more optional fancy window/buffer navigation:
-    - You can turn on the capability to use control and the 
+    - You can turn on the capability to use control and the
       arrow keys to move between windows.
-    - You can turn on the ability to use <C-TAB> and 
-      <C-S-TAB> to open the next and previous (respectively) 
+    - You can turn on the ability to use <C-TAB> and
+      <C-S-TAB> to open the next and previous (respectively)
       buffer in the current window.
-    - You can turn on the ability to use <C-TAB> and 
-      <C-S-TAB> to switch windows (forward and backwards 
+    - You can turn on the ability to use <C-TAB> and
+      <C-S-TAB> to switch windows (forward and backwards
       respectively.)
 
 6.0.4
-    - Added optional fancy window navigation: 
-    - Holding down control and pressing a vim direction 
+    - Added optional fancy window navigation:
+    - Holding down control and pressing a vim direction
       [hjkl] will switch windows in the indicated direction.
 
 6.0.3
@@ -713,8 +713,8 @@ might not take you to the expected window.
       MiniBufExplorer will not automatically open until
       more than one eligible buffers are opened. This
       reduces cluter when you are only working on a
-      single file. 
-      NOTE: See change log for 6.2.2 for more details about 
+      single file.
+      NOTE: See change log for 6.2.2 for more details about
       this feature
 
 6.0.0

--- a/doc/minibufexpl.txt
+++ b/doc/minibufexpl.txt
@@ -5,8 +5,8 @@ CONTENTS                                                *MiniBufExpl-contents*
                                                         *MiniBufExpl*
 
     1. Install................................|MiniBufExplInstall|
-    2. Key Mappings...........................|MiniBufExplKeymap|
-    3. Commands...............................|MiniBufExplCommands|
+    2. Key Mappings...........................|MiniBufExplMappings|
+    3. Commands...............................|MiniBufExplCommand|
     4. Options................................|MiniBufExplOptions|
        4.1 Splits.............................|MiniBufExplSplits|
        4.2 Horizontal Size....................|MiniBufExplWindowSize|

--- a/doc/minibufexpl.txt
+++ b/doc/minibufexpl.txt
@@ -314,7 +314,7 @@ configuring the following highlighting groups:
                             NOT VISIBLE
   MBEVisibleNormal        - buffers that have NOT CHANGED and are
                             VISIBLE
-  MBEVisibleNormalActive  - buffers that have NOT CHANGED and are
+  MBEVisibleActive        - buffers that have NOT CHANGED and are
                             VISIBLE and is the active buffer
   MBEVisibleChanged       - for buffers that have CHANGED and are 
                             VISIBLE

--- a/doc/minibufexpl.txt
+++ b/doc/minibufexpl.txt
@@ -58,7 +58,7 @@ You can map these additional commands as follows:
   map <Leader>t :TMiniBufExplorer<cr>
 
 NOTE: you can change the key binding used in these mappings
-so that they fit with your configuration of vim.
+so that they fit with your configuration of Vim.
 
 You can also call each of these features by typing the following in command
 mode:
@@ -92,7 +92,7 @@ the setting:
                                  " current or on the
                                  " right for vertical split
 
-The default for this is read from the 'splitbelow' VIM option.
+The default for this is read from the 'splitbelow' Vim option.
 
                                                   *'g:miniBufExplSplitToEdge'*
 By default we are now (as of 6.0.2) forcing the -MiniBufExplorer- window to
@@ -120,7 +120,7 @@ It is now (as of 6.1.1) possible to set a maximum height
 for the -MiniBufExplorer- window. You can set the max height by letting the
 following variable in your .vimrc:
 
-  let g:miniBufExplMaxSize = <max lines: defualt 0>
+  let g:miniBufExplMaxSize = <max lines: default 0>
 
 setting this to 0 will mean the window gets as big as needed to fit all your
 buffers.
@@ -268,7 +268,7 @@ following in your .vimrc:
     let g:miniBufExplShowBufNumbers = 0
 
                                             *'g:miniBufExplForceSyntaxEnable'*
-There is a VIM bug that can cause buffers to show up without their
+There is a Vim bug that can cause buffers to show up without their
 highlighting. The following setting will cause MBE to try and turn
 highlighting back on (introduced in 6.3.1):
 
@@ -291,21 +291,21 @@ You can also set a DebugMode to cause output to be target as follows (default
 is mode 3):
 
   let g:miniBufExplorerDebugMode  = 0  " Errors will show up in
-                                       " a vim window
-  let g:miniBufExplorerDebugMode  = 1  " Uses VIM's echo function
+                                       " a Vim window
+  let g:miniBufExplorerDebugMode  = 1  " Uses Vim's echo function
                                        " to display on the screen
   let g:miniBufExplorerDebugMode  = 2  " Writes to a file
                                        " MiniBufExplorer.DBG
   let g:miniBufExplorerDebugMode  = 3  " Store output in global:
                                   " g:miniBufExplorerDebugOutput
 
-Or if you are able to start VIM, you might just perform these at a command
+Or if you are able to start Vim, you might just perform these at a command
 prompt right before you do the operation that is failing.
 
 ==============================================================================
 5. Highlighting                                      *MiniBufExplHighlighting*
 
-It is possible to customize the the highlighting for the tabs in the MBE by
+It is possible to customize the highlighting for the tabs in the MBE by
 configuring the following highlighting groups:
 
   MBENormal               - for buffers that have NOT CHANGED and
@@ -370,7 +370,7 @@ might not take you to the expected window.
                notice is copied with it. Like anything else that's free,
                minibufexpl.vim is provided *as is* and comes with no
                warranty of any kind, either expressed or implied. In no
-               event will the copyright holder be liable for any damamges
+               event will the copyright holder be liable for any damages
                resulting from the use of this software.
 
   Description: Mini Buffer Explorer Vim Plugin
@@ -393,7 +393,7 @@ might not take you to the expected window.
 
 6.4.4
     - Set up proper documentation. Thanks to Claytron :)
-    - Fix colorcolum feature detection. Thanks to sandaya :)
+    - Fix colorcolumn feature detection. Thanks to sandaya :)
     - MBE now ignores buffers with empty name. Thanks to Folke
       for the pull :)
     - Fix incompatibility with tildes in filenames. Thanks to
@@ -412,7 +412,7 @@ might not take you to the expected window.
       re-write!
 
 6.4.1b5
-    - Allow users to turn off Buffer number display on exporer
+    - Allow users to turn off Buffer number display on explorer
       tabs courtesy of jmatraszek.
     - Allow users to turn off duplicate buffer name checking
       to speed up MBE buffer switching. We are working on
@@ -420,7 +420,7 @@ might not take you to the expected window.
       many buffers open.
     - Set Shellslash fix for Windows users so that duplicate
       buffer name checking works properly.
-    - Re-enable synatx highlighitng after cycling the buffer
+    - Re-enable syntax highlighting after cycling the buffer
       courtesy of Sontek.
     - Fix erratic :q behavior when MBE is the last buffer
       courtesy of Moopet.
@@ -494,7 +494,7 @@ might not take you to the expected window.
       navigate.
     - Added g:miniBufExplForceSyntaxEnable setting for folks
       that want a :syntax enable to be called when we enter
-      buffers. This can resolve issues caused by a vim bug
+      buffers. This can resolve issues caused by a Vim bug
       where buffers show up without highlighting when another
       buffer has been closed, quit, wiped or deleted.
 
@@ -585,8 +585,8 @@ might not take you to the expected window.
       specified, but it is depreciated. Use MinSize instead.
     - I now setlocal foldcolumn=0 and nonumber in the MBE
       window. This is for those of you that like to have
-      these options turned on locally. I'm assuming noone
-      outthere wants foldcolumns and line numbers in the
+      these options turned on locally. I'm assuming no one
+      out there wants foldcolumns and line numbers in the
       MBE window? :)
     - Fixed a bug where an empty MBE window was taking half
       of the screen (partly why the MinHeight option was
@@ -636,12 +636,12 @@ might not take you to the expected window.
       idiocyncracies.)
 
 6.0.9
-    - Double clicking tabs was overwriting the cliboard
+    - Double clicking tabs was overwriting the clipboard
       register on MS Windows.  Thanks to Shoeb Bhinderwala
       for reporting this issue.
 
 6.0.8
-    - Apparently some VIM builds are having a hard time with
+    - Apparently some Vim builds are having a hard time with
       line continuation in scripts so the few that were here
       have been removed.
     - Generalized FindExplorer and FindCreateExplorer so
@@ -651,7 +651,7 @@ might not take you to the expected window.
       a buffer which can then be written to disk or emailed
       to me when someone is having a major issue. Can also
       write directly to a file (VERY SLOWLY) on UNIX or Win32
-      (not 95 or 98 at the moment) or use VIM's echo function
+      (not 95 or 98 at the moment) or use Vim's echo function
       to display the output to the screen.
     - Several people have had issues when the hidden option
       is turned on. So I have put in several checks to make
@@ -664,8 +664,8 @@ might not take you to the expected window.
       the MBE UI.)
     - The AutoUpdate code will now close the MBE window when
       there is a single eligible buffer available.
-      This has the usefull side effect of stopping the MBE
-      window from blocking the VIM session open when you close
+      This has the useful side effect of stopping the MBE
+      window from blocking the Vim session open when you close
       the last buffer.
     - Added functions, commands and maps to close & update
       the MBE window (<leader>mbc and <leader>mbu.)
@@ -673,12 +673,12 @@ might not take you to the expected window.
       StartExplorer(1) or StopExplorer(1), which are
       called from the standard mappings. So if you close
       the mbe window with \mbc it won't be automatically
-      opened again unless you do a \mbe (or restart VIM).
+      opened again unless you do a \mbe (or restart Vim).
     - Removed spaces between "tabs" (even more mini :)
     - Simplified MBE tab processing
 
 6.0.6
-    - Fixed register overwrite bug found by S?bastien Pierre
+    - Fixed register overwrite bug found by Sébastien Pierre
 
 6.0.5
     - Fixed an issue with window sizing when we run out of
@@ -696,7 +696,7 @@ might not take you to the expected window.
 
 6.0.4
     - Added optional fancy window navigation:
-    - Holding down control and pressing a vim direction
+    - Holding down control and pressing a Vim direction
       [hjkl] will switch windows in the indicated direction.
 
 6.0.3
@@ -712,7 +712,7 @@ might not take you to the expected window.
     - Added MoreThanOne option and set it on by default
       MiniBufExplorer will not automatically open until
       more than one eligible buffers are opened. This
-      reduces cluter when you are only working on a
+      reduces clutter when you are only working on a
       single file.
       NOTE: See change log for 6.2.2 for more details about
       this feature

--- a/doc/minibufexpl.txt
+++ b/doc/minibufexpl.txt
@@ -6,7 +6,7 @@ CONTENTS                                                *MiniBufExpl-contents*
 
     1. Install................................|MiniBufExplInstall|
     2. Key Mappings...........................|MiniBufExplMappings|
-    3. Commands...............................|MiniBufExplCommand|
+    3. Commands...............................|MiniBufExplCommands|
     4. Options................................|MiniBufExplOptions|
        4.1 Splits.............................|MiniBufExplSplits|
        4.2 Horizontal Size....................|MiniBufExplWindowSize|

--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -409,12 +409,6 @@ augroup NONE
 " }}}
 
 " Functions
-" EscapeTilde - escapes "~" {{{
-function! <SID>EscapeTilde(str)
-   return substitute(a:str, "\\\~","\\\\\~","g")
-endfunction
-" }}}
-"
 " StartExplorer - Sets up our explorer and causes it to be displayed {{{
 "
 function! <SID>StartExplorer(sticky,delBufNum,currBufName)
@@ -544,8 +538,8 @@ function! <SID>StartExplorer(sticky,delBufNum,currBufName)
   call <SID>DisplayBuffers(a:delBufNum,a:currBufName)
 
   if (l:curBuf != -1)
-    let l:bname = <SID>EscapeTilde(expand('#'.l:curBuf.':t'))
-    call search('\['.l:curBuf.':'.l:bname.'\]')
+    let l:bname = expand('#'.l:curBuf.':t')
+    call search('\V['.l:curBuf.':'.l:bname.']')
   else
     call <SID>DEBUG('No current buffer to search for',9)
   endif

--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -26,16 +26,6 @@
 "
 " Startup Check
 "
-" Stop auto starting MBE in diff mode? {{{
-if !exists('g:miniBufExplorerHideWhenDiff')
-    let g:miniBufExplorerHideWhenDiff = 0
-endif
-
-if g:miniBufExplorerHideWhenDiff==1 && &diff
-    let g:miniBufExplorerAutoUpdate = 0
-endif
-" }}}
-
 " Has this plugin already been loaded? {{{
 "
 if exists('loaded_minibufexplorer')
@@ -131,6 +121,16 @@ if !exists('g:miniBufExplorerAutoUpdate')
 endif
 
 " }}}
+" Stop auto starting MBE in diff mode? {{{
+if !exists('g:miniBufExplorerHideWhenDiff')
+    let g:miniBufExplorerHideWhenDiff = 0
+endif
+
+if g:miniBufExplorerHideWhenDiff==1 && &diff
+    let g:miniBufExplorerAutoUpdate = 0
+endif
+" }}}
+
 " MoreThanOne? {{{
 " Display Mini Buf Explorer when there are 'More Than One' eligible buffers
 "

--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -462,7 +462,11 @@ function! <SID>StartExplorer(sticky,delBufNum,curBufNum)
   " them off for the MBE window
   setlocal foldcolumn=0
   setlocal nonumber
-  setlocal norelativenumber
+  if exists("&norelativenumber")
+    " relativenumber was introduced in Vim 7.3 - this provides compatibility
+    " for older versions of Vim
+    setlocal norelativenumber
+  endif
   "don't highlight matching parentheses, etc.
   setlocal matchpairs=
   "Depending on what type of split, make sure the MBE buffer is not

--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -1741,7 +1741,7 @@ function! <SID>DEBUG(msg, level)
         wincmd p
 
         " Get into the debug window or create it if needed
-        call <SID>FindCreateWindow('MiniBufExplorer.DBG', 1, 0, 0)
+        call <SID>FindCreateWindow('MiniBufExplorer.DBG', 1, 1, 0)
 
         " Make sure we really got to our window, if not we
         " will display a confirm dialog and turn debugging

--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -456,6 +456,7 @@ function! <SID>StartExplorer(sticky,delBufNum,currBufName)
   " them off for the MBE window
   setlocal foldcolumn=0
   setlocal nonumber
+  setlocal norelativenumber
   "don't highlight matching parentheses, etc.
   setlocal matchpairs=
   "Depending on what type of split, make sure the MBE buffer is not

--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -545,7 +545,7 @@ function! <SID>StartExplorer(sticky,delBufNum,currBufName)
 
   if (l:curBuf != -1)
     let l:bname = <SID>EscapeTilde(expand('#'.l:curBuf.':t'))
-    call search('\['.l:curBuf.':'.l:bname.'\]')
+    call search('\['.l:curBuf.':'.l:bname.'\]', 'w')
   else
     call <SID>DEBUG('No current buffer to search for',9)
   endif

--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -878,7 +878,7 @@ function! <SID>ShowBuffers(delBufNum,currBufName)
     set noshowcmd 
 
     " Delete all lines in buffer.
-    1,$d _
+    silent 1,$d _
   
     " Goto the end of the buffer put the buffer list 
     " and then delete the extra trailing blank line

--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -1124,7 +1124,7 @@ function! <SID>BuildBufferList(delBufNum, updateBufList, currBufName)
 
         " If the buffer matches the)current buffer name, then  mark it
         call <SID>DEBUG('l:i is '.l:i.' and l:CurrBufName is '.l:CurrBufName,10)
-        if(l:i == l:CurrBufName)
+        if(bufname(l:i) == l:CurrBufName)
             let l:tab .= '!'
         endif
 
@@ -1375,7 +1375,7 @@ function! <SID>AutoUpdate(delBufNum,currBufName)
           let l:ListChanged = <SID>BuildBufferList(a:delBufNum, 0, a:currBufName)
           if (l:ListChanged)
             call <SID>DEBUG('About to call StartExplorer (Update MBE)', 9)
-            call <SID>StartExplorer(0, a:delBufNum, bufnr("%"))
+            call <SID>StartExplorer(0, a:delBufNum, bufname("%"))
           endif
         endif
 

--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -4,7 +4,7 @@
 "
 " Script Info and Documentation  {{{
 "=============================================================================
-"     Copyright: Copyright (C) 2002 & 2003 Bindu Wavell 
+"     Copyright: Copyright (C) 2002 & 2003 Bindu Wavell
 "                Copyright (C) 2010 Oliver Uvman
 "                Copyright (C) 2010 Danielle Church
 "                Copyright (C) 2010 Stephan Sokolow
@@ -16,7 +16,7 @@
 "                warranty of any kind, either expressed or implied. In no
 "                event will the copyright holder be liable for any damamges
 "                resulting from the use of this software.
-" 
+"
 "  Name Of File: minibufexpl.vim
 "   Description: Mini Buffer Explorer Vim Plugin
 " Documentation: See minibufexpl.txt
@@ -37,8 +37,8 @@ let loaded_minibufexplorer = 1
 " Mappings and Commands
 "
 " MBE Keyboard Mappings {{{
-" If we don't already have keyboard mappings for MBE then create them 
-" 
+" If we don't already have keyboard mappings for MBE then create them
+"
 if !hasmapto('<Plug>MiniBufExplorer')
   map <unique> <Leader>mbe <Plug>MiniBufExplorer
 endif
@@ -56,7 +56,7 @@ if !hasmapto('<Plug>MBEMarkCurrent')
 endif
 " }}}
 " MBE <Script> internal map {{{
-" 
+"
 noremap <unique> <script> <Plug>MiniBufExplorer  :call <SID>StartExplorer(1, -1, bufnr("%"))<CR>:<BS>
 noremap <unique> <script> <Plug>CMiniBufExplorer :call <SID>StopExplorer(1)<CR>:<BS>
 noremap <unique> <script> <Plug>UMiniBufExplorer :call <SID>AutoUpdate(-1,bufnr("%"))<CR>:<BS>
@@ -65,7 +65,7 @@ noremap <unique> <script> <Plug>MBEMarkCurrent :call <SID>MarkCurrentBuffer(bufn
 
 " }}}
 " MBE commands {{{
-" 
+"
 if !exists(':MiniBufExplorer')
   command! MiniBufExplorer  call <SID>StartExplorer(1, -1, bufnr("%"))
 endif
@@ -109,12 +109,12 @@ endif
 "     global variable [This is the default]
 if !exists('g:miniBufExplorerDebugMode')
   let g:miniBufExplorerDebugMode = 3
-endif 
+endif
 
 " }}}
 " Allow auto update? {{{
 "
-" We start out with this off for startup, but once vim is running we 
+" We start out with this off for startup, but once vim is running we
 " turn this on.
 if !exists('g:miniBufExplorerAutoUpdate')
   let g:miniBufExplorerAutoUpdate = 0
@@ -122,20 +122,20 @@ endif
 
 " }}}
 " MoreThanOne? {{{
-" Display Mini Buf Explorer when there are 'More Than One' eligible buffers 
+" Display Mini Buf Explorer when there are 'More Than One' eligible buffers
 "
 if !exists('g:miniBufExplorerMoreThanOne')
   let g:miniBufExplorerMoreThanOne = 2
-endif 
+endif
 
 " }}}
 " Split below/above/left/right? {{{
-" When opening a new -MiniBufExplorer- window, split the new windows below or 
+" When opening a new -MiniBufExplorer- window, split the new windows below or
 " above the current window?  1 = below, 0 = above.
 "
 if !exists('g:miniBufExplSplitBelow')
   let g:miniBufExplSplitBelow = &splitbelow
-endif 
+endif
 
 " }}}
 " Split to edge? {{{
@@ -144,7 +144,7 @@ endif
 "
 if !exists('g:miniBufExplSplitToEdge')
   let g:miniBufExplSplitToEdge = 1
-endif 
+endif
 
 " }}}
 " MaxHeight (depreciated) {{{
@@ -154,12 +154,12 @@ endif
 "
 if !exists('g:miniBufExplMaxHeight')
   let g:miniBufExplMaxHeight = 0
-endif 
+endif
 
 " }}}
 " MaxSize {{{
 " Same as MaxHeight but also works for vertical splits if specified with a
-" vertical split then vertical resizing will be performed. If left at 0 
+" vertical split then vertical resizing will be performed. If left at 0
 " then the number of columns in g:miniBufExplVSplit will be used as a
 " static window width.
 if !exists('g:miniBufExplMaxSize')
@@ -179,7 +179,7 @@ endif
 
 " }}}
 " MinSize {{{
-" Same as MinHeight but also works for vertical splits. For vertical splits, 
+" Same as MinHeight but also works for vertical splits. For vertical splits,
 " this is ignored unless g:miniBufExplMax(Size|Height) are specified.
 if !exists('g:miniBufExplMinSize')
   let g:miniBufExplMinSize = g:miniBufExplMinHeight
@@ -188,7 +188,7 @@ endif
 " }}}
 " Horizontal or Vertical explorer? {{{
 " For folks that like vertical explorers, I'm caving in and providing for
-" veritcal splits. If this is set to 0 then the current horizontal 
+" veritcal splits. If this is set to 0 then the current horizontal
 " splitting logic will be run. If however you want a vertical split,
 " assign the width (in characters) you wish to assign to the MBE window.
 "
@@ -222,7 +222,7 @@ endif
 "
 if !exists('g:miniBufExplMapWindowNav')
   " This is for backwards compatibility and may be removed in a
-  " later release, please use the ...NavVim and/or ...NavArrows 
+  " later release, please use the ...NavVim and/or ...NavArrows
   " settings.
   let g:miniBufExplMapWindowNav = 0
 endif
@@ -239,7 +239,7 @@ endif
 " we turn off CTabSwitchWindows.
 if g:miniBufExplMapCTabSwitchBufs == 1 || !exists('g:miniBufExplMapCTabSwitchWindows')
   let g:miniBufExplMapCTabSwitchWindows = 0
-endif 
+endif
 
 "
 " If we have enabled control + vim direction key remapping
@@ -299,13 +299,13 @@ endif
 
 " }}}
 " Single/Double Click? {{{
-" flag that can be set to 1 in a users .vimrc to allow 
+" flag that can be set to 1 in a users .vimrc to allow
 " single click switching of tabs. By default we use
 " double click for tab selection.
 
 if !exists('g:miniBufExplUseSingleClick')
   let g:miniBufExplUseSingleClick = 0
-endif 
+endif
 
 "
 " attempt to perform single click mapping, it would be much
@@ -315,7 +315,7 @@ endif
 "
 if g:miniBufExplUseSingleClick == 1
   let s:clickmap = ':if bufname("%") == "-MiniBufExplorer-" <bar> call <SID>MBEClick() <bar> endif <CR>'
-  if maparg('<LEFTMOUSE>', 'n') == '' 
+  if maparg('<LEFTMOUSE>', 'n') == ''
     " no mapping for leftmouse
     exec ':nnoremap <silent> <LEFTMOUSE> <LEFTMOUSE>' . s:clickmap
   else
@@ -378,15 +378,15 @@ if !exists('g:statusLineText')
 endif
 
 " Variable used to pass maxTabWidth info between functions
-let s:maxTabWidth = 0 
+let s:maxTabWidth = 0
 
 " Variable used to count debug output lines
-let s:debugIndex = 0 
+let s:debugIndex = 0
 
 " Build initial MRUList. This makes sure all the files specified on the
 " command line are picked up correctly.
 let s:MRUList = range(1, bufnr('$'))
-  
+
 " }}}
 " Setup an autocommand group and some autocommands {{{
 " that keep our explorer updated automatically.
@@ -433,7 +433,7 @@ function! <SID>StartExplorer(sticky,delBufNum,currBufName)
   let l:save_rep = &report
   let l:save_sc  = &showcmd
   let &report    = 10000
-  set noshowcmd 
+  set noshowcmd
 
   call <SID>FindCreateWindow('-MiniBufExplorer-', -1, 1, 1)
 
@@ -452,7 +452,7 @@ function! <SID>StartExplorer(sticky,delBufNum,currBufName)
   " We don't want the mouse to change focus without a click
   set nomousefocus
 
-  " If folks turn numbering and columns on by default we will turn 
+  " If folks turn numbering and columns on by default we will turn
   " them off for the MBE window
   setlocal foldcolumn=0
   setlocal nonumber
@@ -462,7 +462,7 @@ function! <SID>StartExplorer(sticky,delBufNum,currBufName)
   "automatically rezised by CTRL + W =, etc...
   setlocal winfixheight
   setlocal winfixwidth
-  
+
   " Set shellslash for Windows/DOS Vim for dupeBufName checking to Work
   if (has("win32") || has("win64"))
       set shellslash
@@ -478,7 +478,7 @@ function! <SID>StartExplorer(sticky,delBufNum,currBufName)
   if exists("+colorcolumn")
       setlocal colorcolumn&
   end
- 
+
   if has("syntax")
     syn clear
     syn match MBENormal                   '\[[^\]]*\]'
@@ -495,7 +495,7 @@ function! <SID>StartExplorer(sticky,delBufNum,currBufName)
     " hi MBEVisibleNormal guifg=#5DC2D6 guibg=fg
     " hi MBEChanged guifg=#CD5907 guibg=fg
     " hi MBENormal guifg=#808080 guibg=fg
-    
+
     if !exists("g:did_minibufexplorer_syntax_inits")
       let g:did_minibufexplorer_syntax_inits = 1
       hi def link MBENormal                Comment
@@ -527,7 +527,7 @@ function! <SID>StartExplorer(sticky,delBufNum,currBufName)
   " If you press w in the -MiniBufExplorer- then switch back
   " to the previous window.
   nnoremap <buffer> p :wincmd p<CR>:<BS>
-  " The following allow us to use regular movement keys to 
+  " The following allow us to use regular movement keys to
   " scroll in a wrapped single line buffer
   nnoremap <buffer> j gj
   nnoremap <buffer> k gk
@@ -540,7 +540,7 @@ function! <SID>StartExplorer(sticky,delBufNum,currBufName)
   nnoremap <buffer> <S-TAB> :call search('\[[0-9]*:[^\]]*\]','b')<CR>:<BS>
   nnoremap <buffer> l   :call search('\[[0-9]*:[^\]]*\]')<CR>:<BS>
   nnoremap <buffer> h :call search('\[[0-9]*:[^\]]*\]','b')<CR>:<BS>
- 
+
   call <SID>DisplayBuffers(a:delBufNum,a:currBufName)
 
   if (l:curBuf != -1)
@@ -557,7 +557,7 @@ function! <SID>StartExplorer(sticky,delBufNum,currBufName)
   call <SID>DEBUG('Completed StartExplorer()'  ,10)
   call <SID>DEBUG('===========================',10)
 
-endfunction 
+endfunction
 
 " }}}
 " StopExplorer - Looks for our explorer and closes the window if it is open {{{
@@ -573,7 +573,7 @@ function! <SID>StopExplorer(sticky)
 
   let l:winNum = <SID>FindWindow('-MiniBufExplorer-', 1)
 
-  if l:winNum != -1 
+  if l:winNum != -1
     exec l:winNum.' wincmd w'
     silent! close
     wincmd p
@@ -602,7 +602,7 @@ function! <SID>ToggleExplorer()
 
   let l:winNum = <SID>FindWindow('-MiniBufExplorer-', 1)
 
-  if l:winNum != -1 
+  if l:winNum != -1
     call <SID>StopExplorer(1)
   else
     call <SID>StartExplorer(1, -1, bufnr("%"))
@@ -617,14 +617,14 @@ endfunction
 
 " }}}
 " FindWindow - Return the window number of a named buffer {{{
-" If none is found then returns -1. 
+" If none is found then returns -1.
 "
 function! <SID>FindWindow(bufName, doDebug)
   if a:doDebug
     call <SID>DEBUG('Entering FindWindow()',10)
   endif
 
-  " Try to find an existing window that contains 
+  " Try to find an existing window that contains
   " our buffer.
   let l:bufNum = bufnr(a:bufName)
   if l:bufNum != -1
@@ -643,11 +643,11 @@ endfunction
 " }}}
 " FindCreateWindow - Attempts to find a window for a named buffer. {{{
 "
-" If it is found then moves there. Otherwise creates a new window and 
+" If it is found then moves there. Otherwise creates a new window and
 " configures it and moves there.
 "
 " forceEdge, -1 use defaults, 0 below, 1 above
-" isExplorer, 0 no, 1 yes 
+" isExplorer, 0 no, 1 yes
 " doDebug, 0 no, 1 yes
 "
 function! <SID>FindCreateWindow(bufName, forceEdge, isExplorer, doDebug)
@@ -664,7 +664,7 @@ function! <SID>FindCreateWindow(bufName, forceEdge, isExplorer, doDebug)
   " Try to find an existing explorer window
   let l:winNum = <SID>FindWindow(a:bufName, a:doDebug)
 
-  " If found goto the existing window, otherwise 
+  " If found goto the existing window, otherwise
   " split open a new window.
   if l:winNum != -1
     if a:doDebug
@@ -752,12 +752,12 @@ endfunction
 " }}}
 " DisplayBuffers - Wrapper for getting MBE window shown {{{
 "
-" Makes sure we are in our explorer, then erases the current buffer and turns 
+" Makes sure we are in our explorer, then erases the current buffer and turns
 " it into a mini buffer explorer window.
 "
 function! <SID>DisplayBuffers(delBufNum,currBufName)
   call <SID>DEBUG('Entering DisplayBuffers()',10)
-  
+
   " Make sure we are in our window
   if bufname('%') != '-MiniBufExplorer-'
     call <SID>DEBUG('DisplayBuffers called in invalid window',1)
@@ -769,9 +769,9 @@ function! <SID>DisplayBuffers(delBufNum,currBufName)
 
   call <SID>ShowBuffers(a:delBufNum,a:currBufName)
   call <SID>ResizeWindow()
-  
+
   normal! zz
-  
+
   " Prevent the buffer from being modified.
   setlocal nomodifiable
   set nobuflisted
@@ -780,8 +780,8 @@ endfunction
 
 " }}}
 " Resize Window - Set width/height of MBE window {{{
-" 
-" Makes sure we are in our explorer, then sets the height/width for our explorer 
+"
+" Makes sure we are in our explorer, then sets the height/width for our explorer
 " window so that we can fit all of our information without taking extra lines.
 "
 function! <SID>ResizeWindow()
@@ -804,7 +804,7 @@ function! <SID>ResizeWindow()
       if (l:width == 0)
         let l:height = winheight('.')
       else
-        let l:height = (l:length / l:width) 
+        let l:height = (l:length / l:width)
         " handle truncation from div
         if (l:length % l:width) != 0
           let l:height = l:height + 1
@@ -818,29 +818,29 @@ function! <SID>ResizeWindow()
       let l:height = line('.')
       normal gg
     endif
-  
+
     " enforce max window height
     if g:miniBufExplMaxSize != 0
       if g:miniBufExplMaxSize < l:height
         let l:height = g:miniBufExplMaxSize
       endif
     endif
-  
+
     " enfore min window height
     if l:height < g:miniBufExplMinSize || l:height == 0
       let l:height = g:miniBufExplMinSize
     endif
-  
+
     call <SID>DEBUG('ResizeWindow to '.l:height.' lines',9)
-  
+
     exec('resize '.l:height)
-  
+
   " Vertical Resize
-  else 
+  else
 
     if g:miniBufExplMaxSize != 0
       let l:newWidth = s:maxTabWidth
-      if l:newWidth > g:miniBufExplMaxSize 
+      if l:newWidth > g:miniBufExplMaxSize
           let l:newWidth = g:miniBufExplMaxSize
       endif
       if l:newWidth < g:miniBufExplMinSize
@@ -856,14 +856,14 @@ function! <SID>ResizeWindow()
     endif
 
   endif
-  
+
 endfunction
 
 " }}}
 " ShowBuffers - Clear current buffer and put the MBE text into it {{{
-" 
-" Makes sure we are in our explorer, then adds a list of all modifiable 
-" buffers to the current buffer. Special marks are added for buffers that 
+"
+" Makes sure we are in our explorer, then adds a list of all modifiable
+" buffers to the current buffer. Special marks are added for buffers that
 " are in one or more windows (*) and buffers that have been modified (+)
 "
 function! <SID>ShowBuffers(delBufNum,currBufName)
@@ -875,12 +875,12 @@ function! <SID>ShowBuffers(delBufNum,currBufName)
     let l:save_rep = &report
     let l:save_sc = &showcmd
     let &report = 10000
-    set noshowcmd 
+    set noshowcmd
 
     " Delete all lines in buffer.
     1,$d _
-  
-    " Goto the end of the buffer put the buffer list 
+
+    " Goto the end of the buffer put the buffer list
     " and then delete the extra trailing blank line
     $
     put! =g:miniBufExplBufList
@@ -893,7 +893,7 @@ function! <SID>ShowBuffers(delBufNum,currBufName)
   else
     call <SID>DEBUG('Buffer list not update since there was no change',9)
   endif
-  
+
 endfunction
 
 " }}}
@@ -909,7 +909,7 @@ endfunction
 
 " }}}
 " CheckRootDirForDupes - Checks if the buffer parent dirs are the same {{{
-" 
+"
 " Compares 2 buffers with the same filename and returns the directory of
 " buffer 1's path at the point where it is different from buffer 2's path
 "
@@ -953,18 +953,18 @@ function! <SID>IgnoreBuffer(buf)
     return 1
   endif
 
-  " Only show modifiable buffers (The idea is that we don't 
+  " Only show modifiable buffers (The idea is that we don't
   " want to show Explorers)
   if (getbufvar(a:buf, '&modifiable') != 1 || l:BufName == '-MiniBufExplorer-')
     return 1
   endif
 
-  return 0 
+  return 0
 endfunction
 
 " }}}
 " BuildBufferList - Build the text for the MBE window {{{
-" 
+"
 " Creates the buffer list string and returns 1 if it is different than
 " last time this was called and 0 otherwise.
 "
@@ -990,7 +990,7 @@ function! <SID>BuildBufferList(delBufNum, updateBufList, currBufName)
         let l:i = l:i + 1
 
         " If we have a delBufNum and it is the current
-        " buffer then ignore the current buffer. 
+        " buffer then ignore the current buffer.
         " Otherwise, continue.
 
         if (a:delBufNum == l:i)
@@ -1038,7 +1038,7 @@ function! <SID>BuildBufferList(delBufNum, updateBufList, currBufName)
                 let l:i2 = l:i2 + 1
                 let l:bufPath = expand( "#" . l:i . ":p")
                 let l:bufPath2 = expand( "#" . l:i2 . ":p")
-                let l:BufName2 = expand( "#" . l:i2 . ":p:t")      
+                let l:BufName2 = expand( "#" . l:i2 . ":p:t")
 
                 call <SID>DEBUG('BUFFER PATHS ---> bufPath is '.l:bufPath.' and bufPath2 is '.l:bufPath2,10)
                 call <SID>DEBUG('BUFFER NAMES ---> bufName is '.l:BufName.' and BufName2 is '.l:BufName2,10)
@@ -1081,7 +1081,7 @@ function! <SID>BuildBufferList(delBufNum, updateBufList, currBufName)
                         endif
                     endif
                 endif
-            endwhile   
+            endwhile
 
             " If there are 2 or more buffers with the same name, let's call a
             " function that show a differentiating parent directory so that the name is unique.
@@ -1105,8 +1105,8 @@ function! <SID>BuildBufferList(delBufNum, updateBufList, currBufName)
 
         if (g:miniBufExplCheckDupeBufs == 0)
             " Get filename & Remove []'s & ()'s
-            let l:shortBufName = fnamemodify(l:BufName, ":t")                  
-            let l:shortBufName = substitute(l:shortBufName, '[][()]', '', 'g') 
+            let l:shortBufName = fnamemodify(l:BufName, ":t")
+            let l:shortBufName = substitute(l:shortBufName, '[][()]', '', 'g')
             let l:tab .= l:shortBufName.']'
         else
 
@@ -1193,8 +1193,8 @@ endfunction
 
 " }}}
 " HasEligibleBuffers - Are there enough MBE eligible buffers to open the MBE window? {{{
-" 
-" Returns 1 if there are any buffers that can be displayed in a 
+"
+" Returns 1 if there are any buffers that can be displayed in a
 " mini buffer explorer. Otherwise returns 0. If delBufNum is
 " any non -1 value then don't include that buffer in the list
 " of eligible buffers.
@@ -1205,8 +1205,8 @@ function! <SID>HasEligibleBuffers(delBufNum)
   let l:save_rep = &report
   let l:save_sc = &showcmd
   let &report = 10000
-  set noshowcmd 
-  
+  set noshowcmd
+
   let l:NBuffers = bufnr('$')     " Get the number of the last buffer.
   let l:i        = 0              " Set the buffer index to zero.
   let l:found    = 0              " No buffer found
@@ -1219,9 +1219,9 @@ function! <SID>HasEligibleBuffers(delBufNum)
   " Loop through every buffer less than the total number of buffers.
   while(l:i <= l:NBuffers && l:found < l:needed)
     let l:i = l:i + 1
-   
+
     " If we have a delBufNum and it is the current
-    " buffer then ignore the current buffer. 
+    " buffer then ignore the current buffer.
     " Otherwise, continue.
     if (a:delBufNum == -1 || l:i != a:delBufNum)
       " Make sure the buffer in question is listed.
@@ -1231,12 +1231,12 @@ function! <SID>HasEligibleBuffers(delBufNum)
         " Check to see if the buffer is a blank or not. If the buffer does have
         " a name, process it.
         if (strlen(l:BufName))
-          " Only show modifiable buffers (The idea is that we don't 
+          " Only show modifiable buffers (The idea is that we don't
           " want to show Explorers)
           if ((getbufvar(l:i, '&modifiable') == 1) && (BufName != '-MiniBufExplorer-'))
-            
+
               let l:found = l:found + 1
-  
+
           endif
         endif
       endif
@@ -1249,7 +1249,7 @@ function! <SID>HasEligibleBuffers(delBufNum)
   call <SID>DEBUG('HasEligibleBuffers found '.l:found.' eligible buffers of '.l:needed.' needed',6)
 
   return (l:found >= l:needed)
-  
+
 endfunction
 
 " }}}
@@ -1306,9 +1306,9 @@ endfunction
 "    we have enough eligible buffers THEN
 " Update our explorer and get back to the current window
 "
-" If we get a buffer number for a buffer that 
-" is being deleted, we need to make sure and 
-" remove the buffer from the list of eligible 
+" If we get a buffer number for a buffer that
+" is being deleted, we need to make sure and
+" remove the buffer from the list of eligible
 " buffers in case we are down to one eligible
 " buffer, in which case we will want to close
 " the MBE window.
@@ -1353,12 +1353,12 @@ function! <SID>AutoUpdate(delBufNum,currBufName)
   endif
 
   call <SID>MRUPush(bufnr("%"))
-  
+
   if (a:delBufNum != -1)
     call <SID>DEBUG('AutoUpdate will make sure that buffer '.a:delBufNum.' is not included in the buffer list.', 5)
     call <SID>MRUPop(a:delBufNum)
   endif
-  
+
   " Only allow updates when the AutoUpdate flag is set
   " this allows us to stop updates on startup.
   if g:miniBufExplorerAutoUpdate == 1
@@ -1375,7 +1375,7 @@ function! <SID>AutoUpdate(delBufNum,currBufName)
         " changed
           let l:ListChanged = <SID>BuildBufferList(a:delBufNum, 0, a:currBufName)
           if (l:ListChanged)
-            call <SID>DEBUG('About to call StartExplorer (Update MBE)', 9) 
+            call <SID>DEBUG('About to call StartExplorer (Update MBE)', 9)
             call <SID>StartExplorer(0, a:delBufNum, bufnr("%"))
           endif
         endif
@@ -1415,7 +1415,7 @@ endfunction
 
 " }}}
 " GetSelectedBuffer - From the MBE window, return the bufnum for buf under cursor {{{
-" 
+"
 " If we are in our explorer window then return the buffer number
 " for the buffer under the cursor.
 "
@@ -1444,7 +1444,7 @@ endfunction
 
 " }}}
 " MBESelectBuffer - From the MBE window, open buffer under the cursor {{{
-" 
+"
 " If we are in our explorer, then we attempt to open the buffer under the
 " cursor in the previous window.
 "
@@ -1458,14 +1458,14 @@ function! <SID>MBESelectBuffer(split)
   " Make sure we are in our window
   if bufname('%') != '-MiniBufExplorer-'
     call <SID>DEBUG('MBESelectBuffer called in invalid window',1)
-    return 
+    return
   endif
 
   let l:save_rep = &report
   let l:save_sc  = &showcmd
   let &report    = 10000
-  set noshowcmd 
-  
+  set noshowcmd
+
   let l:bufnr  = <SID>GetSelectedBuffer()
   let l:resize = 0
 
@@ -1525,10 +1525,10 @@ endfunction
 
 " }}}
 " MBEDeleteBuffer - From the MBE window, delete selected buffer from list {{{
-" 
-" After making sure that we are in our explorer, This will delete the buffer 
+"
+" After making sure that we are in our explorer, This will delete the buffer
 " under the cursor. If the buffer under the cursor is being displayed in a
-" window, this routine will attempt to get different buffers into the 
+" window, this routine will attempt to get different buffers into the
 " windows that will be affected so that windows don't get removed.
 "
 function! <SID>MBEDeleteBuffer(prevBufName)
@@ -1539,7 +1539,7 @@ function! <SID>MBEDeleteBuffer(prevBufName)
   " Make sure we are in our window
   if bufname('%') != '-MiniBufExplorer-'
     call <SID>DEBUG('MBEDeleteBuffer called in invalid window',1)
-    return 
+    return
   endif
 
   let l:curLine    = line('.')
@@ -1555,10 +1555,10 @@ function! <SID>MBEDeleteBuffer(prevBufName)
   let l:save_rep = &report
   let l:save_sc  = &showcmd
   let &report    = 10000
-  set noshowcmd 
-  
-  
-  if l:selBuf != -1 
+  set noshowcmd
+
+
+  if l:selBuf != -1
 
     " Don't want auto updates while we are processing a delete
     " request.
@@ -1574,12 +1574,12 @@ function! <SID>MBEDeleteBuffer(prevBufName)
     call <SID>DEBUG('Previous window: '.l:prevWin.' buffer in window: '.l:prevWinBuf,5)
     call <SID>DEBUG('Selected buffer is <'.l:selBufName.'>['.l:selBuf.']',5)
 
-    " If buffer is being displayed in a window then 
-    " move window to a different buffer before 
-    " deleting this one. 
+    " If buffer is being displayed in a window then
+    " move window to a different buffer before
+    " deleting this one.
     let l:winNum = (bufwinnr(l:selBufName) + 0)
     " while we have windows that contain our buffer
-    while l:winNum != -1 
+    while l:winNum != -1
         call <SID>DEBUG('Buffer '.l:selBuf.' is being displayed in window: '.l:winNum,5)
 
         " move to window that contains our selected buffer
@@ -1594,7 +1594,7 @@ function! <SID>MBEDeleteBuffer(prevBufName)
         call <SID>DEBUG('Window now contains buffer: '.bufnr('%').' which should not be: '.l:selBuf,5)
 
         if l:origBuf == l:curBuf
-            " we wrapped so we are going to have to delete a buffer 
+            " we wrapped so we are going to have to delete a buffer
             " that is in an open window.
             let l:winNum = -1
         else
@@ -1607,7 +1607,7 @@ function! <SID>MBEDeleteBuffer(prevBufName)
     call <SID>DEBUG('Restoring previous window to: '.l:prevWin,5)
     exec l:prevWin.' wincmd w'
 
-    " Try to get back to the -MiniBufExplorer- window 
+    " Try to get back to the -MiniBufExplorer- window
     let l:winNum = bufwinnr(bufnr('-MiniBufExplorer-'))
     if l:winNum != -1
         exec l:winNum.' wincmd w'
@@ -1615,12 +1615,12 @@ function! <SID>MBEDeleteBuffer(prevBufName)
     else
         call <SID>DEBUG('Unable to get to -MiniBufExplorer- window',1)
     endif
-  
+
     " Delete the buffer selected.
     call <SID>DEBUG('About to delete buffer: '.l:selBuf,5)
     exec('silent! bd '.l:selBuf)
 
-    let g:miniBufExplorerAutoUpdate = l:saveAutoUpdate 
+    let g:miniBufExplorerAutoUpdate = l:saveAutoUpdate
     call <SID>DisplayBuffers(-1,a:prevBufName)
     call cursor(l:curLine, l:curCol)
 
@@ -1654,10 +1654,10 @@ endfunction
 " }}}
 " CycleBuffer - Cycle Through Buffers {{{
 "
-" Move to next or previous buffer in the current window. If there 
+" Move to next or previous buffer in the current window. If there
 " are no more modifiable buffers then stay on the current buffer.
 " can be called with no parameters in which case the buffers are
-" cycled forward. Otherwise a single argument is accepted, if 
+" cycled forward. Otherwise a single argument is accepted, if
 " it's 0 then the buffers are cycled backwards, otherwise they
 " are cycled forward.
 "
@@ -1670,7 +1670,7 @@ function! <SID>CycleBuffer(forward)
     resize
     let g:miniBufExplorerAutoUpdate = 0
   endif
-  
+
   " Change buffer (keeping track of before and after buffers)
   let l:origBuf = bufnr('%')
   if (a:forward == 1)
@@ -1724,8 +1724,8 @@ endfunction
 " }}}
 " DEBUG - Display debug output when debugging is turned on {{{
 "
-" Thanks to Charles E. Campbell, Jr. PhD <cec@NgrOyphSon.gPsfAc.nMasa.gov> 
-" for Decho.vim which was the inspiration for this enhanced debugging 
+" Thanks to Charles E. Campbell, Jr. PhD <cec@NgrOyphSon.gPsfAc.nMasa.gov>
+" for Decho.vim which was the inspiration for this enhanced debugging
 " capability.
 "
 function! <SID>DEBUG(msg, level)
@@ -1736,7 +1736,7 @@ function! <SID>DEBUG(msg, level)
     let l:save_rep    = &report
     let l:save_sc     = &showcmd
     let &report       = 10000
-    set noshowcmd 
+    set noshowcmd
 
     " Debug output to a buffer
     if g:miniBufExplorerDebugMode == 0
@@ -1748,8 +1748,8 @@ function! <SID>DEBUG(msg, level)
 
         " Get into the debug window or create it if needed
         call <SID>FindCreateWindow('MiniBufExplorer.DBG', 1, 0, 0)
-    
-        " Make sure we really got to our window, if not we 
+
+        " Make sure we really got to our window, if not we
         " will display a confirm dialog and turn debugging
         " off so that we won't break things even more.
         if bufname('%') != 'MiniBufExplorer.DBG'

--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -417,7 +417,7 @@ autocmd MiniBufExplorer CursorHoldI    * call <SID>DEBUG('-=> CursorHoldI AutoCm
 autocmd MiniBufExplorer VimEnter       * call <SID>DEBUG('-=> VimEnter AutoCmd', 10) |
             \ if g:miniBufExplorerHideWhenDiff!=1 || !&diff |let g:miniBufExplorerAutoUpdate = 1 |endif |
             \ call <SID>AutoUpdate(-1,bufnr("%"))
-augroup NONE
+augroup END
 " }}}
 
 " Functions

--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -938,7 +938,7 @@ endfunction
 "
 function! <SID>IgnoreBuffer(buf)
   " Skip temporary buffers with buftype set.
-  if empty(getbufvar(a:buf, "&buftype") == 0)
+  if empty(getbufvar(a:buf, "&buftype")) == 0
     return 1
   endif
 

--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -682,27 +682,27 @@ function! <SID>FindCreateWindow(bufName, forceEdge, isExplorer, doDebug)
 
           if l:edge
               if g:miniBufExplVSplit == 0
-                  exec 'bo sp '.a:bufName
+                  silent exec 'bo sp '.a:bufName
               else
-                  exec 'bo vsp '.a:bufName
+                  silent exec 'bo vsp '.a:bufName
               endif
           else
               if g:miniBufExplVSplit == 0
-                  exec 'to sp '.a:bufName
+                  silent exec 'to sp '.a:bufName
               else
-                  exec 'to vsp '.a:bufName
+                  silent exec 'to vsp '.a:bufName
               endif
           endif
       else
           if g:miniBufExplVSplit == 0
-              exec 'sp '.a:bufName
+              silent exec 'sp '.a:bufName
           else
               " &splitbelow doesn't affect vertical splits
               " so we have to do this explicitly.. ugh.
               if &splitbelow
-                  exec 'rightb vsp '.a:bufName
+                  silent exec 'rightb vsp '.a:bufName
               else
-                  exec 'vsp '.a:bufName
+                  silent exec 'vsp '.a:bufName
               endif
           endif
       endif
@@ -883,7 +883,7 @@ function! <SID>ShowBuffers(delBufNum,currBufName)
     " and then delete the extra trailing blank line
     $
     put! =g:miniBufExplBufList
-    $ d _
+    silent $ d _
 
     let g:miniBufExplForceDisplay = 0
 

--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -423,7 +423,7 @@ augroup NONE
 " Functions
 " StartExplorer - Sets up our explorer and causes it to be displayed {{{
 "
-function! <SID>StartExplorer(sticky,delBufNum,currBufName)
+function! <SID>StartExplorer(sticky,delBufNum,curBufNum)
   call <SID>DEBUG('===========================',10)
   call <SID>DEBUG('Entering StartExplorer()'   ,10)
   call <SID>DEBUG('===========================',10)
@@ -548,7 +548,7 @@ function! <SID>StartExplorer(sticky,delBufNum,currBufName)
   nnoremap <buffer> l   :call search('\[[0-9]*:[^\]]*\]')<CR>:<BS>
   nnoremap <buffer> h :call search('\[[0-9]*:[^\]]*\]','b')<CR>:<BS>
 
-  call <SID>DisplayBuffers(a:delBufNum,a:currBufName)
+  call <SID>DisplayBuffers(a:delBufNum,a:curBufNum)
 
   if (l:curBuf != -1)
     let l:bname = expand('#'.l:curBuf.':t')
@@ -752,7 +752,7 @@ endfunction
 " Makes sure we are in our explorer, then erases the current buffer and turns
 " it into a mini buffer explorer window.
 "
-function! <SID>DisplayBuffers(delBufNum,currBufName)
+function! <SID>DisplayBuffers(delBufNum,curBufNum)
   call <SID>DEBUG('Entering DisplayBuffers()',10)
 
   " Make sure we are in our window
@@ -764,7 +764,7 @@ function! <SID>DisplayBuffers(delBufNum,currBufName)
   " We need to be able to modify the buffer
   setlocal modifiable
 
-  call <SID>ShowBuffers(a:delBufNum,a:currBufName)
+  call <SID>ShowBuffers(a:delBufNum,a:curBufNum)
   call <SID>ResizeWindow()
 
   normal! zz
@@ -863,10 +863,10 @@ endfunction
 " buffers to the current buffer. Special marks are added for buffers that
 " are in one or more windows (*) and buffers that have been modified (+)
 "
-function! <SID>ShowBuffers(delBufNum,currBufName)
+function! <SID>ShowBuffers(delBufNum,curBufNum)
   call <SID>DEBUG('Entering ShowBuffers()',10)
 
-  let l:ListChanged = <SID>BuildBufferList(a:delBufNum, 1, a:currBufName)
+  let l:ListChanged = <SID>BuildBufferList(a:delBufNum, 1, a:curBufNum)
 
   if (l:ListChanged == 1 || g:miniBufExplForceDisplay)
     let l:save_rep = &report
@@ -965,11 +965,11 @@ endfunction
 " Creates the buffer list string and returns 1 if it is different than
 " last time this was called and 0 otherwise.
 "
-function! <SID>BuildBufferList(delBufNum, updateBufList, currBufName)
+function! <SID>BuildBufferList(delBufNum, updateBufList, curBufNum)
     call <SID>DEBUG('Entering BuildBufferList()',10)
 
 
-    let l:CurrBufName = a:currBufName
+    let l:CurBufNum = a:curBufNum
     let l:NBuffers = bufnr('$')     " Get the number of the last buffer.
     let l:i = 0                     " Set the buffer index to zero.
 
@@ -1121,8 +1121,8 @@ function! <SID>BuildBufferList(delBufNum, updateBufList, currBufName)
         endif
 
         " If the buffer matches the)current buffer name, then  mark it
-        call <SID>DEBUG('l:i is '.l:i.' and l:CurrBufName is '.l:CurrBufName,10)
-        if(bufname(l:i) == l:CurrBufName)
+        call <SID>DEBUG('l:i is '.l:i.' and l:CurBufNum is '.l:CurBufNum,10)
+        if(l:i == l:CurBufNum)
             let l:tab .= '!'
         endif
 
@@ -1310,7 +1310,7 @@ endfunction
 " buffer, in which case we will want to close
 " the MBE window.
 "
-function! <SID>AutoUpdate(delBufNum,currBufName)
+function! <SID>AutoUpdate(delBufNum,curBufNum)
   call <SID>DEBUG('===========================',10)
   call <SID>DEBUG('Entering AutoUpdate('.a:delBufNum.') : '.bufnr('%').' : '.bufname('%'),10)
   call <SID>DEBUG('===========================',10)
@@ -1370,7 +1370,7 @@ function! <SID>AutoUpdate(delBufNum,currBufName)
         else
         " otherwise only update the window if the contents have
         " changed
-          let l:ListChanged = <SID>BuildBufferList(a:delBufNum, 0, a:currBufName)
+          let l:ListChanged = <SID>BuildBufferList(a:delBufNum, 0, a:curBufNum)
           if (l:ListChanged)
             call <SID>DEBUG('About to call StartExplorer (Update MBE)', 9)
             call <SID>StartExplorer(0, a:delBufNum, bufname("%"))

--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -1805,4 +1805,4 @@ function! <SID>CheckForLastWindow()
   endif
 endfunction " }}}
 
-" vim:ft=vim:fdm=marker:ff=unix:nowrap:tabstop=4:shiftwidth=4:softtabstop=4:smarttab:shiftround:expandtab
+" vim:ft=vim:fdm=marker:ff=unix:nowrap:tabstop=2:shiftwidth=2:softtabstop=2:smarttab:shiftround:expandtab

--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -1730,6 +1730,10 @@ function! <SID>DEBUG(msg, level)
 
     " Debug output to a buffer
     if g:miniBufExplorerDebugMode == 0
+        if bufname('%') == 'MiniBufExplorer.DBG'
+            return
+        endif
+
         " Save the current window number so we can come back here
         let l:prevWin     = winnr()
         wincmd p

--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -626,17 +626,7 @@ function! <SID>FindWindow(bufName, doDebug)
 
   " Try to find an existing window that contains
   " our buffer.
-  let l:bufNum = bufnr(a:bufName)
-  if l:bufNum != -1
-    if a:doDebug
-      call <SID>DEBUG('Found buffer ('.a:bufName.'): '.l:bufNum,9)
-    endif
-    let l:winNum = bufwinnr(l:bufNum)
-  else
-    let l:winNum = -1
-  endif
-
-  return l:winNum
+  return bufwinnr(a:bufName)
 
 endfunction
 

--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -26,16 +26,18 @@
 "
 " Startup Check
 "
-" Has this plugin already been loaded? {{{
-"
+" Stop auto starting MBE in diff mode? {{{
 if !exists('g:miniBufExplorerHideWhenDiff')
     let g:miniBufExplorerHideWhenDiff = 0
 endif
 
 if g:miniBufExplorerHideWhenDiff==1 && &diff
-  finish
+    let g:miniBufExplorerAutoUpdate = 0
 endif
+" }}}
 
+" Has this plugin already been loaded? {{{
+"
 if exists('loaded_minibufexplorer')
   finish
 endif
@@ -412,7 +414,9 @@ autocmd MiniBufExplorer BufEnter       * call <SID>DEBUG('-=> BufEnter Checking 
 autocmd MiniBufExplorer BufWritePost   * call <SID>DEBUG('-=> BufWritePost AutoCmd', 10) |call <SID>AutoUpdate(-1,bufnr("%"))
 autocmd MiniBufExplorer CursorHold     * call <SID>DEBUG('-=> CursroHold AutoCmd', 10) |call <SID>AutoUpdateCheck(bufnr("%"))
 autocmd MiniBufExplorer CursorHoldI    * call <SID>DEBUG('-=> CursorHoldI AutoCmd', 10) |call <SID>AutoUpdateCheck(bufnr("%"))
-autocmd MiniBufExplorer VimEnter       * call <SID>DEBUG('-=> VimEnter AutoCmd', 10) |let g:miniBufExplorerAutoUpdate = 1 |call <SID>AutoUpdate(-1,bufnr("%"))
+autocmd MiniBufExplorer VimEnter       * call <SID>DEBUG('-=> VimEnter AutoCmd', 10) |
+            \ if g:miniBufExplorerHideWhenDiff!=1 || !&diff |let g:miniBufExplorerAutoUpdate = 1 |endif |
+            \ call <SID>AutoUpdate(-1,bufnr("%"))
 augroup NONE
 " }}}
 

--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -28,6 +28,14 @@
 "
 " Has this plugin already been loaded? {{{
 "
+if !exists('g:miniBufExplorerHideWhenDiff')
+    let g:miniBufExplorerHideWhenDiff = 0
+endif
+
+if g:miniBufExplorerHideWhenDiff==1 && &diff
+  finish
+endif
+
 if exists('loaded_minibufexplorer')
   finish
 endif


### PR DESCRIPTION
`norelativenumber` is a feature added in Vim 7.3, but not everyone has Vim 7.3 on all their boxes.  This commit wraps that option in a feature check to prevent errors because of older versions of Vim.
