### PR TITLE
Fix syntax matching pattern for visible buffers

### DIFF
--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -543,8 +543,8 @@ function! <SID>RenderSyntax()
     syn match MBEChanged                  '\[[^\]]*\]+'
     syn match MBEVisibleNormal            '\[[^\]]*\]\*'
     syn match MBEVisibleChanged           '\[[^\]]*\]\*+'
-    syn match MBEVisibleActiveNormal      '\[[^\]]*\]\*!'
-    syn match MBEVisibleActiveChanged     '\[[^\]]*\]\*+!'
+    syn match MBEVisibleActiveNormal      '\[[^\]]*\]\*\!'
+    syn match MBEVisibleActiveChanged     '\[[^\]]*\]\*+\!'
 
     "MiniBufExpl Color Examples
     " hi MBENormal               guifg=#808080 guibg=fg


### PR DESCRIPTION
The `!` in the pattern needs to be escaped in order for it to match properly.
