### PR TITLE
Update to stop MBE's automatically display

### DIFF
--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -2035,7 +2035,7 @@ function! <SID>HasEligibleBuffers()
   call <SID>DEBUG('Found '.l:found.' eligible buffers of '.l:needed.' needed',6)
 
   call <SID>DEBUG('Leaving HasEligibleBuffers()',10)
-  return (l:found >= l:needed)
+  return ((l:needed > 1 || winnr('$') > 1) && l:found >= l:needed)
 endfunction
 
 " }}}


### PR DESCRIPTION
Currently if we let g:miniBufExplBuffersNeeded=1, then open a file and do some modifies on it, MBE will automatically display, since we don't need it. So I made some changes:
If 'g:miniBufExplBuffersNeeded' OR 'g:miniBufExplBuffersNeeded' is less than 2, the MBE window will not auto open until the number of windows is greater than 1.
@see HasEligibleBuffers()
