### PR TITLE
Display, and jump to, the buffer numbers as seen by MBE, in both normal and MRU mode.

### DIFF
--- a/doc/minibufexpl.txt
+++ b/doc/minibufexpl.txt
@@ -151,6 +151,16 @@ configuration of Vim.
     Toggle the buffer listing order of the MBE window between its default and
     most recently used in every tab page.
 
+:MBEGoTo <N>                                                        *:MBEGoTo*
+    Go to buffer N in MBE's buffer list, meaning that the left-most buffer
+    shown in the MBE window is 1, the next one to the right is 2, and so on,
+    regardless of actual buffer number.  Goes well with
+    g:miniBufExplShowBufMBENumbers
+
+:MBEMRUGoTo <N>                                                  *:MBEMRUGoTo*
+    Same as MBEGoTo except that it uses the MRU buffer list intead of the
+    normal list.
+
 :MBEbn                                                                *:MBEbn*
     Switch to next normal buffer in current window.
 

--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -501,16 +501,19 @@ function! <SID>TabEnterHandler()
 endfunction
 
 function! <SID>BufAddHandler()
-  call <SID>DEBUG('Entering BufAdd Handler', 10)
+  " If not in command line window; see https://vi.stackexchange.com/questions/14315/how-can-i-tell-if-im-in-the-command-window
+  if mode() == 'n' && getcmdwintype() == ''
+    call <SID>DEBUG('Entering BufAdd Handler', 10)
 
-  call <SID>ListAdd(s:BufList,str2nr(expand("<abuf>")))
-  call <SID>ListAdd(s:MRUList,str2nr(expand("<abuf>")))
+    call <SID>ListAdd(s:BufList,str2nr(expand("<abuf>")))
+    call <SID>ListAdd(s:MRUList,str2nr(expand("<abuf>")))
 
-  call <SID>UpdateAllBufferDicts(expand("<abuf>"),0)
+    call <SID>UpdateAllBufferDicts(expand("<abuf>"),0)
 
-  call <SID>AutoUpdate(bufnr("%"),0)
+    call <SID>AutoUpdate(bufnr("%"),0)
 
-  call <SID>DEBUG('Leaving BufAdd Handler', 10)
+    call <SID>DEBUG('Leaving BufAdd Handler', 10)
+  endif
 endfunction
 
 function! <SID>BufEnterHandler() abort


### PR DESCRIPTION
I was annoyed with not be able to jump to buffers by number (because buffer numbers drift), so I wrote this.  I've tested it in every mode I could think of, but that's probably not everything.
