### PR TITLE
Better check for MBE window

### DIFF
--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -610,8 +610,7 @@ function! <SID>StartExplorer(curBufNum)
   " make the syntax highlight in MBE window working
   call s:SwitchWindow('w',0,l:winNum)
 
-  " Make sure we are in our window
-  if bufname('%') != '-MiniBufExplorer-'
+  if !s:IsOwnWindow()
     call <SID>DEBUG('StartExplorer called in invalid window',1)
     call <SID>DEBUG('Leaving StartExplorer()',10)
     return
@@ -1090,8 +1089,7 @@ endfunction
 function! <SID>DisplayBuffers(curBufNum)
   call <SID>DEBUG('Entering DisplayExplorer('.a:curBufNum.')',10)
 
-  " Make sure we are in our window
-  if bufname('%') != '-MiniBufExplorer-'
+  if !s:IsOwnWindow()
     call <SID>DEBUG('DisplayBuffers called in invalid window',1)
     return
   endif
@@ -1120,8 +1118,7 @@ endfunction
 function! <SID>ResizeWindow()
   call <SID>DEBUG('Entering ResizeWindow()',10)
 
-  " Make sure we are in our window
-  if bufname('%') != '-MiniBufExplorer-'
+  if !s:IsOwnWindow()
     call <SID>DEBUG('ResizeWindow called in invalid window',1)
     call <SID>DEBUG('Leaving ResizeWindow()',10)
     return
@@ -1240,8 +1237,7 @@ endfunction
 function! <SID>ShowBuffers()
   call <SID>DEBUG('Entering ShowExplorer()',10)
 
-  " Make sure we are in our window
-  if bufname('%') != '-MiniBufExplorer-'
+  if !s:IsOwnWindow()
     call <SID>DEBUG('ShowBuffers called in invalid window',1)
     call <SID>DEBUG('Leaving ShowBuffers()',10)
     return
@@ -2185,8 +2181,7 @@ endfunction
 function! <SID>GetSelectedBuffer()
   call <SID>DEBUG('Entering GetSelectedBuffer()',10)
 
-  " Make sure we are in our window
-  if bufname('%') != '-MiniBufExplorer-'
+  if !s:IsOwnWindow()
     call <SID>DEBUG('GetSelectedBuffer called in invalid window',1)
     call <SID>DEBUG('Leaving GetSelectedBuffer()',10)
     return -1
@@ -2225,8 +2220,7 @@ endfunction
 function! <SID>MBESelectBuffer(split)
   call <SID>DEBUG('Entering MBESelectBuffer()',10)
 
-  " Make sure we are in our window
-  if bufname('%') != '-MiniBufExplorer-'
+  if !s:IsOwnWindow()
     call <SID>DEBUG('MBESelectBuffer called in invalid window',1)
     call <SID>DEBUG('Leaving MBESelectBuffer()',10)
     return
@@ -2282,8 +2276,7 @@ endfunction
 function! <SID>MBEDeleteBuffer()
   call <SID>DEBUG('Entering MBEDeleteBuffer()',10)
 
-  " Make sure we are in our window
-  if bufname('%') != '-MiniBufExplorer-'
+  if !s:IsOwnWindow()
     call <SID>DEBUG('MBEDeleteBuffer called in invalid window',1)
     call <SID>DEBUG('Leaving MBEDeleteBuffer()',10)
     return
@@ -2492,6 +2485,15 @@ function! s:SwitchWindow(action, ...)
   call <SID>DEBUG('current window is: '.winnr(),10)
 
   call <SID>DEBUG('Leaving SwitchWindow()',10)
+endfunction
+
+" }}}
+
+" }}}
+" s:IsOwnWindow {{{
+"
+function! s:IsOwnWindow()
+  return bufname('%') =~ '-MiniBufExplorer-' && &buftype == 'nofile'
 endfunction
 
 " }}}


### PR DESCRIPTION
The original issue: https://github.com/weynhamz/vim-plugin-minibufexpl/issues/46

This should fix the old issue from [fholgado/minibufexpl.vim#119](https://github.com/fholgado/minibufexpl.vim/issues/119), I don't think it has been resolved yet.

The problem is, at various places this check is performed:

        if bufname('%') != '-MiniBufExplorer-'

to validate the window is indeed MBE's window. Initially that is fine as the `bufname` matches '-MiniBufExplorer-' exactly.

But after a directory change, it changes to something like:

        /<some-paths...>/.vim_runtime/-MiniBufExplorer-

So this PR performs a better check for MBE's own window.