### PR TITLE
Disable cursorline to avoid bg color override

### DIFF
--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -1564,6 +1564,8 @@ function! <SID>BuildBufferList(curBufNum)
             let l:miniBufExplBufList = l:miniBufExplBufList . "\n"
         endif
     endfor
+    " trim whitespaces
+    let l:miniBufExplBufList = substitute(l:miniBufExplBufList, '^\s*\(.\{-}\)\s*$', '\1', '')
 
     if (s:miniBufExplBufList != l:miniBufExplBufList)
         let s:maxTabWidth = l:maxTabWidth

--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -531,6 +531,8 @@ endfunction
 " RenderSyntax {{{
 "
 function! <SID>RenderSyntax()
+  "Avoid background color override by cursorline
+  setlocal nocursorline
   if has("syntax")
     syn clear
     syn match MBENormal                   '\[[^\]]*\]'


### PR DESCRIPTION
When trying to set the color scheme for MBE, I noticed that background colors where ignored. This was caused by the cursorline being set to the one and only line in the MBE buffer. Disabling the cursorline allows setting background colors.